### PR TITLE
Added implementation for multiple preset configurations.

### DIFF
--- a/Source/Unicorn/SerializationUtility.cs
+++ b/Source/Unicorn/SerializationUtility.cs
@@ -1,26 +1,40 @@
-﻿using System.Collections.Generic;
-using Sitecore.Configuration;
+﻿using Sitecore.Configuration;
 using Sitecore.Data.Serialization.Presets;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
 
 namespace Unicorn
 {
 	public static class SerializationUtility
 	{
 		/// <summary>
-		/// Gets the default presets specified in configuration/sitecore/serialization/default
+		/// Gets the presets specified in configuration/sitecore/serialization
 		/// </summary>
 		public static IList<IncludeEntry> GetPreset()
 		{
-			return GetPreset("default");
+			var config = Factory.GetConfigNode("serialization");
+			if (config != null) 
+				return config.ChildNodes.OfType<XmlNode>().SelectMany(GetPreset).ToList();
+
+			return null;
 		}
 
 		/// <summary>
-		/// Gets the default presets specified in configuration/sitecore/serialization/name
+		/// Gets the presets specified in configuration/sitecore/serialization/name
 		/// </summary>
 		public static IList<IncludeEntry> GetPreset(string name)
 		{
 			var config = Factory.GetConfigNode("serialization/" + name);
-			if(config != null)
+			return GetPreset(config);
+		}
+
+		/// <summary>
+		/// Gets the presets of a specific XmlNode
+		/// </summary>
+		public static IList<IncludeEntry> GetPreset(XmlNode config)
+		{
+			if (config != null)
 				return PresetFactory.Create(config);
 
 			return null;


### PR DESCRIPTION
I added the functionality to configure multiple presets. This will give you the possibility to make more detailed configurations. I tested it with two nodes and it works, even if both are named "default". If the serialization node is missing completely, Sitecore will throw a `NullReferenceException` when you try to save an item. But as I read the code, this would be the same behavior as before the change. But seriously, who would not specify a serialization node when using Unicorn ;)

If you'd like, I could update the serialization.config file in the documentation folder to show the possiblity. Just let me know.
