### PR TITLE
Adding auto sync and auto publish

### DIFF
--- a/Documentation/Serialization.config
+++ b/Documentation/Serialization.config
@@ -46,5 +46,14 @@ specifies which items to auto-serialize, and adds a saveUI handler to prevent ov
 				<handler type="Unicorn.FilteredItemHandler, Unicorn" method="OnItemVersionRemoved"/>
 			</event>
 		</events>
-	</sitecore>
+    <pipelines>
+      <initialize>
+        <processor type="Unicorn.FilteredItemLoader, Unicorn" />
+      </initialize>
+    </pipelines>
+    <settings>
+      <setting name="UnicornSyncDatabase" value="false"/>
+      <setting name="UnicornPublishDatabase" value="false"/>
+    </settings>
+  </sitecore>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ When deploying to a Content Delivery server, the Unicorn sync tool page and seri
 
 [Andrew Lansdowne](https://twitter.com/Rangler2) has also written a post specifically about [setting up Unicorn with TeamCity and WebDeploy](http://andrew.lansdowne.me/2013/06/07/auto-deploy-sitecore-items-using-unicorn-and-teamcity/) that may be useful when setting up automated deployments.
 
+You can also enable automatic database syncronization by setting "UnicornSyncDatabase" value to "true" in the Serialization.config and set "UnicornPublishDatabase" to "true" if you want to automatically publish the items after the syncronization.
+
 ## Unicorn's Sync Rules
 
 * The disk is considered the master at all times. The event handlers make this usable, because local changes are already serialized on disk (and so updates from SCM must merge with local at that time just like code)

--- a/Source/Unicorn/FilteredItemLoader.cs
+++ b/Source/Unicorn/FilteredItemLoader.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Linq;
+using Sitecore.Configuration;
+using Sitecore.Data;
+using Sitecore.Data.Serialization.Presets;
+using Sitecore.Diagnostics;
+using Sitecore.Pipelines;
+using Sitecore.Publishing;
+using Sitecore.SecurityModel;
+
+namespace Unicorn
+{
+    public class FilteredItemLoader
+    {
+        public void Process(PipelineArgs args)
+        {
+            var syncDatabase = Settings.GetBoolSetting("UnicornSyncDatabase", false);
+            if (!syncDatabase)
+            {
+                Log.Warn("Unicorn automatic sync to database is disabled.", this);
+                return;
+            }
+
+            // load the requested (or default) preset
+            var presets = SerializationUtility.GetPreset("default").ToList();
+            if (!presets.Any())
+            {
+                Log.Warn("Unicorn preset did not exist in configuration.", this);
+                return;
+            }
+
+            presets.ForEach(ProcessPreset);
+
+            var publishDatabase = Settings.GetBoolSetting("UnicornPublishDatabase", false);
+            if (!publishDatabase)
+            {
+                return;
+            }
+
+            presets.ForEach(PublishPreset);
+        }
+
+        private void ProcessPreset(IncludeEntry preset)
+        {
+            var options = new AdvancedLoadOptions(preset)
+            {
+                ForceUpdate = false,
+                DeleteOrphans = true
+            };
+
+            try
+            {
+                using (new SecurityDisabler())
+                {
+                    new SerializationLoader().LoadTree(options);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Unicorn unable to process preset", ex, this);
+                throw;
+            }
+        }
+
+        private void PublishPreset(IncludeEntry preset)
+        {
+            if (preset.Database != "master")
+            {
+                return;
+            }
+
+            var master = Factory.GetDatabase("master");
+            var target = Factory.GetDatabase("web");
+            var home = master.GetItem(preset.Path);
+            Database[] targetDatabases = { target };
+            try
+            {
+                PublishManager.PublishItem(home, targetDatabases, master.Languages, true, true);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Unicorn unable to publish preset", ex, this);
+                throw;
+            }
+        }
+    }
+}

--- a/Source/Unicorn/Unicorn.csproj
+++ b/Source/Unicorn/Unicorn.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="AdvancedLoadOptions.cs" />
     <Compile Include="FilteredItemHandler.cs" />
+    <Compile Include="FilteredItemLoader.cs" />
     <Compile Include="PresetExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializationConflictProcessor.cs" />


### PR DESCRIPTION
Enable automatic database syncronization by setting "UnicornSyncDatabase" value to "true" in the Serialization.config and set "UnicornPublishDatabase" to "true" if you want to automatically publish the items after the syncronization.
