### PR TITLE
Shifted config path resolution along 1 char to avoid '\\' path issue

### DIFF
--- a/src/Unicorn/ConfigurationUtility.cs
+++ b/src/Unicorn/ConfigurationUtility.cs
@@ -8,9 +8,9 @@ namespace Unicorn
 		/// </summary>
 		public static string ResolveConfigurationPath(string configPath)
 		{
-			if (configPath.StartsWith("~"))
+			if (configPath.StartsWith("~/"))
 			{
-				return System.Web.Hosting.HostingEnvironment.MapPath("~/") + configPath.Substring(1).Replace('/', '\\');
+				return System.Web.Hosting.HostingEnvironment.MapPath("~") + configPath.Substring(2).Replace('/', '\\');
 				// +1 to Stack Overflow:
 				// http://stackoverflow.com/questions/4742257/how-to-use-server-mappath-when-httpcontext-current-is-nothing
 			}


### PR DESCRIPTION
When serializing some items from deeper in the tree, we kept coming up against a 'Path is not under the root' error.  This was being caused by Sitecore having to use GetShortPath() as the path to the item was too long and 'ResolveConfigurationPath' was returning a path with '\\' for web root paths.

While most file-related methods can cope with a path that contains '\\', eg 'C:\github\sitecore\project1', GetShortPath() doesn't.

You can recreate this by having an item in your tree with a path of longer than 150 characters (assuming a SerializationFolderPathMaxLength of 90), and setting your serializationProvider rootPath to a web-root-relative path.
