### PR TITLE
Configurations with only users also no root paths

### DIFF
--- a/src/Unicorn/SerializationHelper.cs
+++ b/src/Unicorn/SerializationHelper.cs
@@ -393,7 +393,7 @@ namespace Unicorn
 					}
 					else
 					{
-						logger.Warn($"{configuration.Name} had no root paths included to sync. If you're only syncing roles, this is expected. Otherwise it indicates that your predicate has no included items and you need to add some.");
+						logger.Warn($"{configuration.Name} had no root paths included to sync. If you're only syncing roles and/or users, this is expected. Otherwise it indicates that your predicate has no included items and you need to add some.");
 					}
 				}
 			}


### PR DESCRIPTION
This change clarifies the existing warning about configurations with only roles.