### PR TITLE
Add Config Roles to Standard Config Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There is also a series of blog posts detailing Unicorn 3 (and why the Rainbow se
 ## Best Practices
 
 * If using [Helix architecture](http://helix.sitecore.net/) plan to use one Unicorn configuration per module. You can use [Unicorn 4's configuration conventions](https://kamsar.net/index.php/2017/02/Unicorn-4-Part-III-Configuration-Enhancements/) to avoid repetition and promote a consistent item architecture across modules.
-* Make sure to enable and disable configuration files appropriately when developing, and deploying to CE/CM and CD environments. Each config file has a comment header that details when it should be enabled and disabled. Most important is to disable the data provider config when deployed.
+* If using Sitecore 9 or the [Sitecore Configuration Roles module](https://github.com/Sitecore/Sitecore-Configuration-Roles), the Unicorn configuration files are automatically enabled or disabled based on the server role that they are deployed to. If not, make sure to enable and disable configuration files appropriately when developing, and deploying to CE/CM and CD environments. Each config file has a comment header that details when it should be enabled and disabled. Most important is to disable the data provider config when deployed.
 * Always automate your deployments of Unicorn items (see _Automated Deployment_ below). This ensures a consistent item state during deployments.
 * Consider automating _local development_ Unicorn syncing using scripts (e.g. PowerShell or Gulp), which can enable you to have a one-click "post-pull" experience that both builds your projects and syncs any item changes in. [Sitecore Habitat](https://github.com/sitecore/habitat) does this using a combination of Gulp and the Unicorn PowerShell API.
 

--- a/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
@@ -7,8 +7,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<pipelines>
 			<unicornSyncComplete>
 				<!-- at the end of each configuration's sync, we throw the items it changed into ManualPublishQueueHandler's queue -->

--- a/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
@@ -9,8 +9,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone">
 		<dataProviders>
 			<!--
 				Register the Unicorn data provider for use. If a database hooks to the Unicorn data provider it will

--- a/src/Unicorn/Standard Config Files/Unicorn.Deployed.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.Deployed.config.disabled
@@ -8,8 +8,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="ContentManagement">
 		<processors>
 			<saveUI>
 				<!--

--- a/src/Unicorn/Standard Config Files/Unicorn.Dilithium.config.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Dilithium.config.example
@@ -25,8 +25,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<unicorn>
 			<defaults>
 				<!-- 

--- a/src/Unicorn/Standard Config Files/Unicorn.PowerShell.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.PowerShell.config
@@ -22,8 +22,8 @@
 	
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<powershell>
 			<commandlets>
 				<add Name="Unicorn Commandlets" type="*, Unicorn" />

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.config
@@ -7,8 +7,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<unicorn>
 			<!-- 
 				Authentication Provider


### PR DESCRIPTION
Add config roles to standard config files so that it's no longer required to rename/delete standard config files at release time on Sitecore instances running Sitecore 9 or the [Sitecore Configuration Roles module](https://github.com/Sitecore/Sitecore-Configuration-Roles).

* `Unicorn.AutoPublish.config`: header says to remove from CD environments, so apply to only `Standalone` or `ContentManagement`.
* `Unicorn.config`: not needed.
* `Unicorn.Configs.Default.example`: not needed.
* `Unicorn.Configs.Dependency.config.example`: not needed.
* `Unicorn.Configs.NewItemsOnly.example`: not needed.
* `Unicorn.CustomSerializationFolder.config.example`: probably not needed.
* `Unicorn.DataProvider.config`: header says to remove from *any* deployed instance, so apply to only `Standalone`. I'm torn on this one since `Standalone` could mean either your local dev environment or a combined CM/CD environment. In the case of the latter, it probably shouldn't be enabled. 🤷‍♂️ 
* `Unicorn.Deployed.config.disabled`: header says to deploy to only CM environment, so apply only to `ContentManagement`. Torn on this one as well, because it should probably be enabled in combined CM/CD environments. Also, should we enable this one and expect users without config roles to delete/disable it in the appropriate environments going forward? 🤷‍♀️ 
* `Unicorn.Dilithium.config.example`: header says to apply to only local dev or CM environment, so apply to `Standalone` or `ContentManagement`.
* `Unicorn.PowerShell.config`: header says to apply to only local dev or CM environment, so apply to `Standalone` or `ContentManagement`.
* `Unicorn.Remote.config.disabled`: didn't bother since it only applies to local dev.
* `Unicorn.UI.config`: header says to remove from CD environments, so apply to only `Standalone` or `ContentManagement`.
* `Unicorn.zSharedSecret.config.example`: not needed.

I tested the `role:require="Standalone"` attribute in Sitecore 8.0, 8.1, and 8.2 instances without the Configuration Roles module installed and had no issues. As expected, Sitecore just ignores the attribute.