### PR TITLE
Add Config Roles to Unicorn.Roles and Unicorn.Users Configs

### DIFF
--- a/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.DataProvider.config
+++ b/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.DataProvider.config
@@ -8,8 +8,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone">
 		<events>
 			<event name="role:created">
 				<handler type="Unicorn.Roles.Events.UnicornRolesEventHandler, Unicorn.Roles" method="RoleCreated" />

--- a/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.config
+++ b/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.config
@@ -10,14 +10,14 @@
 	
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<unicorn>
 			<defaults>
 				<!-- Note: do not colocate serialized items and serialized roles in the same folder -->
 				<roleDataStore physicalRootPath="$(dataFolder)\Unicorn\Unicorn.Roles\$(configurationName)" type="Unicorn.Roles.Data.FilesystemRoleDataStore, Unicorn.Roles" singleInstance="true"/>
 				<roleLoader type="Unicorn.Roles.Loader.RoleLoader, Unicorn.Roles" singleInstance="true" />
-					<roleLoaderLogger type="Unicorn.Roles.Loader.DefaultRoleLoaderLogger, Unicorn.Roles" singleInstance="true" />
+				<roleLoaderLogger type="Unicorn.Roles.Loader.DefaultRoleLoaderLogger, Unicorn.Roles" singleInstance="true" />
 
 				<roleSerializationFormatter type="Unicorn.Roles.Formatting.YamlRoleSerializationFormatter, Unicorn.Roles" singleInstance="true" />
 				

--- a/src/Unicorn.Users/Standard Config Files/Unicorn.Users.DataProvider.config
+++ b/src/Unicorn.Users/Standard Config Files/Unicorn.Users.DataProvider.config
@@ -8,8 +8,8 @@
 
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone">
 		<events>
 			<event name="user:created">
 				<handler type="Unicorn.Users.Events.UnicornUsersEventHandler, Unicorn.Users" method="UserCreated" />

--- a/src/Unicorn.Users/Standard Config Files/Unicorn.Users.config
+++ b/src/Unicorn.Users/Standard Config Files/Unicorn.Users.config
@@ -10,14 +10,14 @@
 	
 	http://github.com/kamsar/Unicorn
 -->
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+	<sitecore role:require="Standalone or ContentManagement">
 		<unicorn>
 			<defaults>
 				<!-- Note: do not colocate serialized items and serialized users in the same folder -->
 				<userDataStore physicalRootPath="$(dataFolder)\Unicorn\Unicorn.Users\$(configurationName)" type="Unicorn.Users.Data.FilesystemUserDataStore, Unicorn.Users" singleInstance="true"/>
 				<userLoader type="Unicorn.Users.Loader.UserLoader, Unicorn.Users" singleInstance="true" />
-					<userLoaderLogger type="Unicorn.Users.Loader.DefaultUserLoaderLogger, Unicorn.Users" singleInstance="true" />
+				<userLoaderLogger type="Unicorn.Users.Loader.DefaultUserLoaderLogger, Unicorn.Users" singleInstance="true" />
 
 				<userSerializationFormatter type="Unicorn.Users.Formatting.YamlUserSerializationFormatter, Unicorn.Users" singleInstance="true" />
 				


### PR DESCRIPTION
Add config roles to `Unicorn.Roles` and `Unicorn.Users` config files so that it's no longer required to rename/delete standard config files at release time on Sitecore instances running Sitecore 9 or the [Sitecore Configuration Roles module](https://github.com/Sitecore/Sitecore-Configuration-Roles).

* `Unicorn.Roles.DataProvider.config`: header says to remove from *any* deployed instance, so apply to only `Standalone`.
* `Unicorn.Roles.config`: header says to apply to only local dev or CM environment, so apply to `Standalone` or `ContentManagement`.
* `Unicorn.Users.DataProvider.config`: header says to remove from *any* deployed instance, so apply to only `Standalone`.
* `Unicorn.Users.config`: header says to apply to only local dev or CM environment, so apply to `Standalone` or `ContentManagement`.