### PR TITLE
Update Kamsar.WebConsole dependency to latest version

### DIFF
--- a/src/Unicorn.Tests/Unicorn.Tests.csproj
+++ b/src/Unicorn.Tests/Unicorn.Tests.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Kamsar.WebConsole, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Kamsar.WebConsole.2.0.0\lib\net40\Kamsar.WebConsole.dll</HintPath>
+    <Reference Include="Kamsar.WebConsole, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Kamsar.WebConsole.2.0.1\lib\net40\Kamsar.WebConsole.dll</HintPath>
     </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>

--- a/src/Unicorn.Tests/packages.config
+++ b/src/Unicorn.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="AutoFixture.Xunit2" version="3.50.2" targetFramework="net452" />
   <package id="Configy" version="1.0.0" targetFramework="net452" />
   <package id="FluentAssertions" version="4.19.2" targetFramework="net452" />
-  <package id="Kamsar.WebConsole" version="2.0.0" targetFramework="net452" />
+  <package id="Kamsar.WebConsole" version="2.0.1" targetFramework="net452" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net452" />
   <package id="MicroCHAP" version="1.2.2.2" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />

--- a/src/Unicorn/Unicorn.csproj
+++ b/src/Unicorn/Unicorn.csproj
@@ -43,8 +43,8 @@
     <Reference Include="Configy, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Configy.1.0.0\lib\net45\Configy.dll</HintPath>
     </Reference>
-    <Reference Include="Kamsar.WebConsole, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Kamsar.WebConsole.2.0.0\lib\net40\Kamsar.WebConsole.dll</HintPath>
+    <Reference Include="Kamsar.WebConsole, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Kamsar.WebConsole.2.0.1\lib\net40\Kamsar.WebConsole.dll</HintPath>
     </Reference>
     <Reference Include="MicroCHAP, Version=1.2.2.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MicroCHAP.1.2.2.2\lib\net45\MicroCHAP.dll</HintPath>

--- a/src/Unicorn/packages.config
+++ b/src/Unicorn/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Configy" version="1.0.0" targetFramework="net452" />
-  <package id="Kamsar.WebConsole" version="2.0.0" targetFramework="net452" />
+  <package id="Kamsar.WebConsole" version="2.0.1" targetFramework="net452" />
   <package id="MicroCHAP" version="1.2.2.2" targetFramework="net452" />
   <package id="Sitecore.ContentSearch.NoReferences" version="8.2.160729" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.ExperienceEditor.Speak.NoReferences" version="8.2.160729" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
Update `Kamsar.WebConsole` NuGet packages to `2.0.1` so they don't need to be updated after installing `Unicorn`.

For issue #309.