### PR TITLE
Change Sitecore sign in URL to /sitecore/login

### DIFF
--- a/src/Unicorn/ControlPanel/Controls/AccessDenied.cs
+++ b/src/Unicorn/ControlPanel/Controls/AccessDenied.cs
@@ -21,7 +21,7 @@ namespace Unicorn.ControlPanel.Controls
 			writer.WriteLine("    `.            :.,\'");
 			writer.WriteLine("      `-.________,-\'");
 			writer.WriteLine("-->");
-			writer.Write("<p>You need to <a href=\"/sitecore/admin/login.aspx?ReturnUrl={0}\">sign in to Sitecore as an administrator</a> to use the Unicorn control panel.</p>", HttpUtility.UrlEncode(HttpContext.Current.Request.Url.PathAndQuery));
+			writer.Write($"<p>You need to <a href=\"/sitecore/login?returnUrl={HttpUtility.UrlEncode(HttpContext.Current.Request.Url.PathAndQuery)}\">sign in to Sitecore as an administrator</a> to use the Unicorn control panel.</p>");
 
 			HttpContext.Current.Response.TrySkipIisCustomErrors = true;
 


### PR DESCRIPTION
Change Sitecore login URL on Unicorn Access Denied page from `/sitecore/admin/login.aspx` to `/sitecore/login` to fix 401 error.

For issue #314.