### PR TITLE
Enable PackageReference support for contentFiles in nuspecs

### DIFF
--- a/Build/Unicorn.Roles.nuget/Unicorn.Roles.nuspec
+++ b/Build/Unicorn.Roles.nuget/Unicorn.Roles.nuspec
@@ -12,15 +12,25 @@
 		<description>Adds security role syncing to Unicorn. This package contains both the core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Roles.Core if you only want the library.</description>
 		<copyright>Copyright 2018</copyright>
 		<tags>sitecore serialization</tags>
-	<dependencies>
-		<dependency id="Unicorn" version="$version$" />
-		<dependency id="Unicorn.Roles.Core" version="$version$" />
-	</dependencies>
+		<dependencies>
+			<dependency id="Unicorn" version="$version$" />
+			<dependency id="Unicorn.Roles.Core" version="$version$" />
+		</dependencies>
+		<!-- PackageReference support -->
+		<contentFiles>
+			<files include="any/**/*" buildAction="Content" copyToOutput="true" />
+		</contentFiles>
 	</metadata>
 	<files>
+		<!-- PackageReference support -->
+		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Roles.config" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Roles.DataProvider.config" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Configs.Default.Roles.config.example" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<!-- legacy content folder -->
 		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Roles.config" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Roles.DataProvider.config" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn.Roles\Standard Config Files\Unicorn.Configs.Default.Roles.config.example" target="content\App_Config\Include\Unicorn" />
+		<!-- Other assets -->
 		<file src="readme.txt" target="" />
 	</files>
 </package>

--- a/Build/Unicorn.Users.nuget/Unicorn.Users.nuspec
+++ b/Build/Unicorn.Users.nuget/Unicorn.Users.nuspec
@@ -12,14 +12,24 @@
 		<description>Adds user syncing to Unicorn. This package contains both the core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Users.Core if you only want the library.</description>
 		<copyright>Copyright 2018</copyright>
 		<tags>sitecore serialization</tags>
-	<dependencies>
-		<dependency id="Unicorn.Users.Core" version="$version$" />
-	</dependencies>
+		<dependencies>
+			<dependency id="Unicorn.Users.Core" version="$version$" />
+		</dependencies>
+		<!-- PackageReference support -->
+		<contentFiles>
+			<files include="any/**/*" buildAction="Content" copyToOutput="true" />
+		</contentFiles>
 	</metadata>
 	<files>
+		<!-- PackageReference support -->
+		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Users.config" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Users.DataProvider.config" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Configs.Default.Users.config.example" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<!-- legacy content folder -->
 		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Users.config" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Users.DataProvider.config" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn.Users\Standard Config Files\Unicorn.Configs.Default.Users.config.example" target="content\App_Config\Include\Unicorn" />
+		<!-- Other assets -->
 		<file src="readme.txt" target="" />
 	</files>
 </package>

--- a/Build/Unicorn.nuget/Unicorn.nuspec
+++ b/Build/Unicorn.nuget/Unicorn.nuspec
@@ -12,15 +12,35 @@
 		<description>Unicorn is a utility for Sitecore that solves the issue of moving templates, renderings, and other database items between Sitecore instances. This package contains both the Unicorn core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Core if you only want the library.</description>
 		<copyright>Copyright 2018</copyright>
 		<tags>sitecore serialization</tags>
-	<dependencies>
-		<dependency id="Unicorn.Core" version="$version$" />
-		<dependency id="Rainbow" version="$rainbowversion$" />
-	</dependencies>
+		<dependencies>
+			<dependency id="Unicorn.Core" version="$version$" />
+			<dependency id="Rainbow" version="$rainbowversion$" />
+		</dependencies>
+		<!--
+			PackageReference support
+			Describes how assets will be restored whent the pacakge is consumed
+			We want all assets to be used as content files
+			The include path is rooted to the contentFiles path
+		-->
+		<contentFiles>
+			<files include="any/**/*" buildAction="Content" copyToOutput="true" />
+		</contentFiles>
 	</metadata>
 	<files>
+		<!--
+			PackageReference support
+			contentFiles\{language}\{tfm}
+			lanuguage - cs, vb etc. We use any as the assets are not language specific
+			tfm - net462,netstandard2.0 etc - We use any as the assets are not runtime specific
+		-->
+		<file src="..\..\src\Unicorn\Standard Config Files\*.config" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn\Standard Config Files\*.disabled" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<file src="..\..\src\Unicorn\Standard Config Files\*.example" target="contentFiles\any\any\App_Config\Include\Unicorn" />
+		<!-- legacy content folder -->
 		<file src="..\..\src\Unicorn\Standard Config Files\*.config" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn\Standard Config Files\*.disabled" target="content\App_Config\Include\Unicorn" />
 		<file src="..\..\src\Unicorn\Standard Config Files\*.example" target="content\App_Config\Include\Unicorn" />
+		<!-- Other assets -->
 		<file src="readme.txt" target="" />
 		<file src="..\..\doc\PowerShell Remote Scripting\*.*" target="tools\PSAPI" />
 	</files>


### PR DESCRIPTION
Additions to nuspecs to support `contentFiles` when a package is restored using `PackageReference`.

The contents of the generated packages have been manually validated but some additional testing (e.g. integration) should be completed to confirm the requirements are met.

Assets are copied to `<output>/App_Config/Include/Unicorn/<path>` during build or publish.