### PR TITLE
Fix Control Panel Authentication for Sitecore 9.1

### DIFF
--- a/src/Unicorn/ControlPanel/Controls/AccessDenied.cs
+++ b/src/Unicorn/ControlPanel/Controls/AccessDenied.cs
@@ -1,4 +1,4 @@
-﻿using System.Web;
+using System.Web;
 using System.Web.UI;
 
 namespace Unicorn.ControlPanel.Controls
@@ -21,7 +21,7 @@ namespace Unicorn.ControlPanel.Controls
 			writer.WriteLine("    `.            :.,\'");
 			writer.WriteLine("      `-.________,-\'");
 			writer.WriteLine("-->");
-			writer.Write($"<p>You need to <a href=\"/sitecore/login?returnUrl={HttpUtility.UrlEncode(HttpContext.Current.Request.Url.PathAndQuery)}\">sign in to Sitecore as an administrator</a> to use the Unicorn control panel.</p>");
+			writer.Write($"<p>You need to <a href=\"{GetLoginUrl()}\">sign in to Sitecore as an administrator</a> to use the Unicorn control panel.</p>");
 
 			HttpContext.Current.Response.TrySkipIisCustomErrors = true;
 
@@ -29,6 +29,12 @@ namespace Unicorn.ControlPanel.Controls
 			// Returning 418 I'm a Teapot, instead. Unicorn refuses to brew coffee to people not authenticated.
 			// Assuming it is doubtful Sitecore has, or will ever, do any special handling for this situation.
 			HttpContext.Current.Response.StatusCode = 418;
+		}
+
+		private static string GetLoginUrl()
+		{
+			var returnUrl = HttpUtility.UrlEncode(HttpContext.Current.Request.Url.PathAndQuery);
+			return $"{Sitecore.Context.Site.LoginPage}?returnUrl={returnUrl}";
 		}
 	}
 }

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.IdentityServer.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.IdentityServer.config.disabled
@@ -1,0 +1,26 @@
+<!--
+	Unicorn UI Identity Server Configuration
+
+	This file enables the Unicorn control panel to work with authentication in Sitecore 9.1 and above.
+
+	This file should not be enabled on versions of Sitecore prior to 9.1.
+
+	http://github.com/kamsar/Unicorn
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/" xmlns:security="http://www.sitecore.net/xmlconfig/security/">
+	<sitecore role:require="Standalone or ContentManagement" security:require="Sitecore">
+		<pipelines>
+			<!--
+				The Unicorn control panel path must be added to the list of site neutral paths for the Unicorn control panel to work with authentication in 9.1.
+				This must match the activationUrl defined in the UnicornControlPanelPipelineProcessor defined in Unicorn.UI.config.
+			-->
+			<owin.cookieAuthentication.validateIdentity>
+				<processor type="Sitecore.Owin.Authentication.Pipelines.CookieAuthentication.ValidateIdentity.ValidateSiteNeutralPaths, Sitecore.Owin.Authentication">
+					<siteNeutralPaths hint="list">
+						<path hint="unicorn">/unicorn.aspx</path>
+					</siteNeutralPaths>
+				</processor>
+			</owin.cookieAuthentication.validateIdentity>
+		</pipelines>
+	</sitecore>
+</configuration>

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.config
@@ -47,6 +47,8 @@
 			<httpRequestBegin>
 				<!--
 					This pipeline handler shows the Unicorn control panel. You can customize the URL the control panel lives at by changing the activationUrl.
+					On Sitecore 9.1 and above, you must also update the site neutral paths in the owin.cookieAuthentication.validateIdentity pipeline defined in
+					Unicorn.UI.IdentityServer.config when you customize the control panel URL.
 					The activationUrl must be a URL that the Sitecore pipeline won't ignore (e.g. .aspx, .ashx, etc)
 					The activationSite must be a site that doesn't use Language Fallback or Enforce Version Presence
 				-->

--- a/src/Unicorn/Unicorn.csproj
+++ b/src/Unicorn/Unicorn.csproj
@@ -285,6 +285,9 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Standard Config Files\Unicorn.PowerShell.config" />
+    <None Include="Standard Config Files\Unicorn.UI.IdentityServer.config.disabled">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Standard Config Files\Unicorn.zSharedSecret.config.example">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
### Fix Authentication Issue in 9.1
Fix control panel authentication issue for 9.1 raised in issue #326. Sitecore 9.1 requires any URL path that does not map to a site (e.g., `/unicorn.aspx`) be added to the "Site Neutral Paths" in the `owin.cookieAuthentication.validateIdentity` pipeline for the Context User to be resolved properly. Without this, the Context User will always be resolved as `extranet\anonymous`.

⚠ **The config changes required for this are not compatible with 9.0.X** ⚠
The `owin.cookieAuthentication.validateIdentity` pipeline doesn't exist in 7.X and 8.X, so this config change is benign in those versions. The pipeline does exist in 9.0.X, but the `ValidateSiteNeutralPaths` processor doesn't, so patching this change in to 9.0.X will cause exceptions. For the time being, I've added this change in a new config file that's disabled by default: `Unicorn.UI.IdentityServer.config.disabled`.

Sitecore 9.1 introduced a new config role, `security`, that I tried to use so these config changes won't affect 9.0.X; however, since `security:define` isn't set in the 9.0.X `Web.config` app settings, `security:require` is ignored and the config changes get applied anyway.

We have a few options to approach this:
1. Instruct 9.1+ users to enable `Unicorn.UI.IdentityServer.config.disabled` in their solution.
2. Enable `Unicorn.UI.IdentityServer.config` by default, and instruct 9.0.X users to disable it in their solution.
3. Enable `Unicorn.UI.IdentityServer.config` by default, and instruct 9.0.X users to add `<add key="security:define" value="undefined" />` to the app settings in `Web.config`. 👎
4. @kamsar suggested that we could create a 9.1+ version of the Unicorn NuGet package with the necessary config changes enabled by default. This would also give us a chance to move the configs to the `\App_Config\Modules` folder.

### Fix Redirect after Login Issue in 9.1
In PR #315 we changed the login URL from `/sitecore/admin/login.aspx` to `/sitecore/login`. This URL works on 9.1, but you get sent to the Launch Pad instead of `/unicorn.aspx` after logging in through the Unicorn control panel. The login URL defined on the context site respects the `redirectUrl` in 9.1, and it is also backwards compatible down to 7.0.

### Verified
I verified that these changes work on the following versions:
- 8.0 Initial Release
- 8.2 Update-7
- 9.0 Update-2
- 9.1 Initial Release.