### PR TITLE
childrenOfPath exclusion now obeys wildcard paths for exceptions.

### DIFF
--- a/src/Unicorn/Predicates/Exclusions/ChildrenOfPathBasedPresetTreeExclusion.cs
+++ b/src/Unicorn/Predicates/Exclusions/ChildrenOfPathBasedPresetTreeExclusion.cs
@@ -42,24 +42,15 @@ namespace Unicorn.Predicates.Exclusions
 			// you may preserve certain children from exclusion
 			foreach (var exception in _exceptions)
 			{
-				var fullPath = exception.Item1;
+				var exceptionPath = exception.Item1;
 				var exceptionRule = exception.Item2;
+				var escapedItemPath = itemPath.Replace("*", @"\*");
 
-				var unescapedExceptionPath = fullPath.Replace(@"\*", "*");
-
-				if (exceptionRule.IncludeChildren)
+				if (PathTool.ComparePathSegments(PathTool.ExplodePath(escapedItemPath), 
+													PathTool.ExplodePath(exceptionPath), 
+													exceptionRule.IncludeChildren))
 				{
-					if (itemPath.StartsWith(unescapedExceptionPath, StringComparison.OrdinalIgnoreCase))
-					{
-						return new PredicateResult(true);
-					}
-				}
-				else
-				{
-					if (itemPath.Equals(unescapedExceptionPath, StringComparison.OrdinalIgnoreCase))
-					{
-						return new PredicateResult(true);
-					}
+					return new PredicateResult(true);
 				}
 			}
 

--- a/src/Unicorn/Predicates/Exclusions/PathTool.cs
+++ b/src/Unicorn/Predicates/Exclusions/PathTool.cs
@@ -1,7 +1,51 @@
-﻿namespace Unicorn.Predicates.Exclusions
+﻿using System;
+
+namespace Unicorn.Predicates.Exclusions
 {
 	internal static class PathTool
 	{
+		internal static bool ComparePathSegments(string[] path1, string[] path2, bool allowPartialMatch = false)
+		{
+			if (!allowPartialMatch && path1?.Length != path2?.Length)
+			{
+				return false;
+			}
+
+			var segments = Math.Min(path1.Length, path2.Length);
+			for (var i = 0; i < segments; i++)
+			{
+				var segment1 = path1[i];
+				var segment2 = path2[i];
+
+				const string wildcard = "*";
+				if (wildcard.Equals(segment1, StringComparison.Ordinal) 
+					|| wildcard.Equals(segment2, StringComparison.Ordinal))
+				{
+					continue;
+				}
+
+				if (!string.Equals(segment1, segment2, StringComparison.OrdinalIgnoreCase))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		internal static string[] ExplodePath(string path)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+			{
+				return new string[] {};
+			}
+
+			var safePath = EnsureTrailingSlash(path);
+			var pathSegments = safePath.Split(new[] { '/' } , StringSplitOptions.RemoveEmptyEntries);
+
+			return pathSegments;
+		}
+
 		internal static string EnsureTrailingSlash(string path)
 		{
 			if (path.EndsWith("/")) return path;


### PR DESCRIPTION
When an include predicate uses a `childrenOfPath` exclude statement, exceptions would not evaluate Unicorn wildcard paths. This has been updated to use a path segment comparison to ensure that any configured unicorn, wildcard paths get correctly identified as an exception.

Example CoP configuration:
```
			  <include name="Data" database="master" path="/sitecore/content/MyTenant/MySite/Data">
				  <exclude childrenOfPath="*">
					  <except name="Component Library"></except>
				  </exclude>
			  </include>

```
- Added two new methods to the PathTool class to provide consistency with path comparisons. 
- Item path escaping rules for Sitecore wildcard items have been "inversed" in the `ChildrenOfPathBasedPresetTreeExclusion` class for exceptions. This was done since it was possible to define a configuration where path comparisons would previously incorrectly match against Sitecore wildcard items.