### PR TITLE
Improved Unicorn sync module

### DIFF
--- a/doc/PowerShell Remote Scripting/sample.ps1
+++ b/doc/PowerShell Remote Scripting/sample.ps1
@@ -7,13 +7,13 @@ $ScriptPath = Split-Path $MyInvocation.MyCommand.Path
 Import-Module $ScriptPath\Unicorn.psm1
 
 # SYNC ALL CONFIGURATIONS
-Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here'
+Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -StreamLogs
 
 # SYNC SPECIFIC CONFIGURATIONS
-Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -Configurations @('Test1', 'Test2')
+Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -Configurations @('Test1', 'Test2') -StreamLogs
 
 # SYNC ALL CONFIGURATIONS, SKIPPING ANY WITH TRANSPARENT SYNC ON
-Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -SkipTransparentConfigs
+Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -SkipTransparentConfigs -StreamLogs
 
 # Note: you may pass -Verb 'Reserialize' for remote reserialize. Usually not needed though.
 


### PR DESCRIPTION
Extended basic module to allow both streaming and just receiving logs; exposed collected errors and warnings as global variables for consumption by calling process and further processing.
Frankly speaking, it is real pain, trying to find what Unicorn configuration threw an error while executing Unicorn sync when you have more than 100 of them.
So, I made this example module little bit bigger and make it expose errors, warnings, unicorn whole log and publishing data in global variables `unicornErrors, unicornWarnings, unicornLog,unicornEndOfWork` for further consumption and processing