### PR TITLE
Publish manager

### DIFF
--- a/src/Unicorn/Publishing/ManualPublishQueueHandler.cs
+++ b/src/Unicorn/Publishing/ManualPublishQueueHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using Kamsar.WebConsole;
+using Sitecore.Configuration;
 using Sitecore.Data;
 using Sitecore.Data.Items;
 using Sitecore.Publishing;
@@ -17,6 +18,9 @@ namespace Unicorn.Publishing
 	public class ManualPublishQueueHandler : PublishProcessor
 	{
 		private static readonly ConcurrentQueue<ID> ManuallyAddedCandidates = new ConcurrentQueue<ID>();
+		protected static bool UsePublishManager = Settings.GetBoolSetting("Unicorn.UsePublishManager", true);
+		protected static bool UsePublishingService = Settings.GetBoolSetting("Unicorn.UsePublishingService", false);
+		protected static int PublishingServiceMaxItemsToQueue = Settings.GetIntSetting("Unicorn.PublishingServiceMaxItemsToQueue", 50);
 
 		public static void AddItemToPublish(Guid itemId)
 		{
@@ -28,17 +32,72 @@ namespace Unicorn.Publishing
 		public static bool PublishQueuedItems(Item triggerItem, Database[] targets, ILogger logger = null)
 		{
 			if (ManuallyAddedCandidates.Count == 0) return false;
+			var suffix = ManuallyAddedCandidates.Count == 1 ? string.Empty : "s";
+			var compareRevisions = false;
 
-			foreach (var database in targets)
+			if (!UsePublishingService)
 			{
-				var suffix = ManuallyAddedCandidates.Count == 1 ? string.Empty : "s";
-				logger?.Debug($"> Publishing {ManuallyAddedCandidates.Count} synced item{suffix} in queue to {database.Name}");
+				foreach (var database in targets)
+				{
+					logger?.Debug($"> Publishing {ManuallyAddedCandidates.Count} synced item{suffix} in queue to {database.Name}");
+					var publishOptions = new PublishOptions(triggerItem.Database, database, PublishMode.SingleItem, triggerItem.Language, DateTime.UtcNow) { RootItem = triggerItem, CompareRevisions = compareRevisions, RepublishAll = true };
+					if (UsePublishManager)
+					{
+						// this works much faster then `new Publisher(publishOptions, triggerItem.Database.Languages).PublishWithResult();`
+						var handle = PublishManager.Publish(new PublishOptions[] { publishOptions });
+						var publishingSucces = PublishManager.WaitFor(handle);
 
-				var publishOptions = new PublishOptions(triggerItem.Database, database, PublishMode.SingleItem, triggerItem.Language, DateTime.UtcNow) { RootItem = triggerItem, CompareRevisions = false, RepublishAll = true };
+						if (publishingSucces)
+						{
+							logger?.Debug($"> Published synced item{suffix} to {database.Name}. Statistics is not retrievable when Publish Manager is used (see setting Unicorn.UsePublishManager comments).");
+						}
+						else
+						{
+							logger?.Error($"> Error happened during publishing. Check Sitecore logs for details.");
+						}
 
-				var result = new Publisher(publishOptions, triggerItem.Database.Languages).PublishWithResult();
+					}
+					else
+					{
+						var result = new Publisher(publishOptions, triggerItem.Database.Languages).PublishWithResult();
 
-				logger?.Debug($"> Published synced items to {database.Name} (New: {result.Statistics.Created}, Updated: {result.Statistics.Updated}, Deleted: {result.Statistics.Deleted} Skipped: {result.Statistics.Skipped})");
+						logger?.Debug($"> Published synced item{suffix} to {database.Name} (New: {result.Statistics.Created}, Updated: {result.Statistics.Updated}, Deleted: {result.Statistics.Deleted} Skipped: {result.Statistics.Skipped})");
+					}
+				}
+			}
+			else
+			{
+				var counter = 0;
+				var triggerItemDatabase = triggerItem.Database;
+				var deepModePublish = false;
+				var publishRelatedItems = false;
+
+				logger?.Debug($"> Queueing {ManuallyAddedCandidates.Count} synced item{suffix} in publishing service.");
+
+				if (ManuallyAddedCandidates.Count <= PublishingServiceMaxItemsToQueue)
+				{
+					// using publishing service to manually queue items in publishing service
+					while (ManuallyAddedCandidates.Count > 0)
+					{
+						ID itemId;
+						ManuallyAddedCandidates.TryDequeue(out itemId);
+
+						var publishCandidateItem = triggerItemDatabase.GetItem(itemId);
+						if (publishCandidateItem != null)
+						{
+							counter++;
+							PublishManager.PublishItem(publishCandidateItem, targets, triggerItemDatabase.Languages, deepModePublish, compareRevisions, publishRelatedItems);
+						}
+					}
+
+					logger?.Debug($"> Queued {counter} synced item{suffix} in publishing service.");
+				} 
+				else
+				{
+					// we have more than maxItemsToQueue
+					PublishManager.PublishSmart(triggerItemDatabase, targets, triggerItemDatabase.Languages);
+					logger?.Debug($"> Since we have more than {PublishingServiceMaxItemsToQueue} synced items - it is counter-productive to queue them one-by-one, so we are publishing whole database to all targets.");
+				}
 			}
 
 			// clear the queue after we publish

--- a/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
@@ -18,7 +18,8 @@
 			<unicornSyncEnd>
 				<!-- when all configurations have synced, fire off a publish that processes the queue we've accumulated -->
 				<processor type="Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems, Unicorn">
-					<PublishTriggerItemId>/sitecore/templates/Common/Folder</PublishTriggerItemId> <!-- the trigger item can be any leaf node Sitecore item - just has to have a 'starting point' for the publish -->
+					<PublishTriggerItemId>/sitecore/templates/Common/Folder</PublishTriggerItemId>
+					<!-- the trigger item can be any leaf node Sitecore item - just has to have a 'starting point' for the publish -->
 					<!-- these are the database(s) to publish synced items to -->
 					<TargetDatabases hint="list:AddTargetDatabase">
 						<web>web</web>
@@ -34,5 +35,20 @@
 				<processor patch:after="*[@type='Sitecore.Publishing.Pipelines.Publish.AddItemsToQueue, Sitecore.Kernel']" type="Unicorn.Publishing.ManualPublishQueueHandler, Unicorn"/>
 			</publish>
 		</pipelines>
+		<settings>
+			<!--
+				Unicorn will use Publish Manager for items publishing, which routes items publishing through Sitecore publishing service, in case it is used. 
+				Default value is true (if not specified). This setting is required for Sitecore versions lower then 
+			-->
+			<setting name="Unicorn.UsePublishManager" value="true" />
+			<!--
+				There is no uniform way to learn, if we are using publishing service or not (even setting PublishingServiceUrlRoot have changed between versions :( ). Publishing service ignores publish queue and we need to build own queue for it when building handle for PublishManager -> hence, we need a separate setting for this.
+			-->
+			<setting name="Unicorn.UsePublishingService" value="false" />
+			<!--
+				If we have synced more that items number in this setting - it is faster to queue just smart publish in Publishing service than queueing individual items.
+			-->
+			<setting name="Unicorn.PublishingServiceMaxItemsToQueue" value="50" />
+		</settings>
 	</sitecore>
 </configuration>


### PR DESCRIPTION
This solves #256 
Also, if you do not have Publishing Service, but using most recent Sitecore version (as far as I remember - PublishManager was introduced in Sitecore 8) - you will still be able to benefit from faster publishes.
Here is my measurements:
initial sync of a project produces 9000 synced items.

 - with old publishing approach Sync-Unicorn fails with timeout exception: ```Error: Sync-Unicorn : Exception calling "ReadLine" with "0" argument(s): "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or```

 - with PublishManager (executing without publishing service) it completes in ```728710ms```

Measurements was made on clean Sitecore installation with clean databases
