### PR TITLE
Cleanup links/data to have the project more up-to-date

### DIFF
--- a/Build/Unicorn.Roles.nuget/Unicorn.Roles.nuspec
+++ b/Build/Unicorn.Roles.nuget/Unicorn.Roles.nuspec
@@ -5,12 +5,12 @@
 		<version>$version$</version>
 		<authors>Kam Figy, Mark Cassidy</authors>
 		<owners>Kam Figy</owners>
-		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+		<licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
 		<projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-		<iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+		<iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Adds security role syncing to Unicorn. This package contains both the core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Roles.Core if you only want the library.</description>
-		<copyright>Copyright 2018</copyright>
+		<copyright>Copyright 2020</copyright>
 		<tags>sitecore serialization</tags>
 	<dependencies>
 		<dependency id="Unicorn" version="$version$" />

--- a/Build/Unicorn.Users.nuget/Unicorn.Users.nuspec
+++ b/Build/Unicorn.Users.nuget/Unicorn.Users.nuspec
@@ -5,12 +5,12 @@
 		<version>$version$</version>
 		<authors>Kam Figy, Mark Cassidy</authors>
 		<owners>Kam Figy</owners>
-		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+		<licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
 		<projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-		<iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+		<iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Adds user syncing to Unicorn. This package contains both the core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Users.Core if you only want the library.</description>
-		<copyright>Copyright 2018</copyright>
+		<copyright>Copyright 2020</copyright>
 		<tags>sitecore serialization</tags>
 	<dependencies>
 		<dependency id="Unicorn.Users.Core" version="$version$" />

--- a/Build/Unicorn.nuget/Unicorn.nuspec
+++ b/Build/Unicorn.nuget/Unicorn.nuspec
@@ -5,12 +5,12 @@
 		<version>$version$</version>
 		<authors>Kam Figy, Mark Cassidy</authors>
 		<owners>Kam Figy</owners>
-		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+		<licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
 		<projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-		<iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+		<iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Unicorn is a utility for Sitecore that solves the issue of moving templates, renderings, and other database items between Sitecore instances. This package contains both the Unicorn core library and the configuration for it, which is appropriate for web projects. Install Unicorn.Core if you only want the library.</description>
-		<copyright>Copyright 2018</copyright>
+		<copyright>Copyright 2020</copyright>
 		<tags>sitecore serialization</tags>
 	<dependencies>
 		<dependency id="Unicorn.Core" version="$version$" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![la la la la](http://kamsar.net/index.php/2015/09/Unicorn-3-What-s-new/Unicorn_logo.png)
+![la la la la](https://kamsar.net/index.php/2015/09/Unicorn-3-What-s-new/Unicorn_logo.png)
 
 Unicorn is a utility for Sitecore that solves the issue of moving templates, renderings, and other database items between Sitecore instances. This becomes problematic when developers have their own local instances - packages are error-prone and tend to be forgotten on the way to production. Unicorn solves this issue by writing serialized copies of Sitecore items to disk along with the code - this way, a copy of the necessary database items for a given codebase accompanies it in source control.
 
@@ -6,17 +6,17 @@ For basic usage, Unicorn has two moving parts:
 * Data provider - The default Sitecore data provider is extended to automatically serialize item changes as they are made to Sitecore. This means that at any given time, what's serialized is the "master copy."
 * Control panel - this tool (/unicorn.aspx) is a page that can sync the state of Sitecore to the state stored on disk (respecting presets and exclusions). You do this after you pull down someone else's serialized changes from source control.
 
-Unicorn avoids the need to manually select changes to merge unlike some other serialization-based solutions because the disk is always kept up to date by the data provider. This means that if you pull changes in from someone else's Sitecore instance you will have to immediately merge and/or conflict resolve the serialized files in your source control system - leaving the disk always the master copy of everything. Then if you execute the sync page, the merged changes are synced into your Sitecore database. Unicorn uses the [Rainbow](https://github.com/kamsar/Rainbow) serialization engine, which uses some format enhancements that make it far simpler to merge than the Sitecore default format.
+Unicorn avoids the need to manually select changes to merge unlike some other serialization-based solutions because the disk is always kept up to date by the data provider. This means that if you pull changes in from someone else's Sitecore instance you will have to immediately merge and/or conflict resolve the serialized files in your source control system - leaving the disk always the master copy of everything. Then if you execute the sync page, the merged changes are synced into your Sitecore database. Unicorn uses the [Rainbow](https://github.com/SitecoreUnicorn/Rainbow) serialization engine, which uses some format enhancements that make it far simpler to merge than the Sitecore default format.
 
 ## Is this like TDS?
 
 Unicorn solves some of the same issues as [Hedgehog's TDS](https://www.hhogdev.com/products/team-development-for-sitecore/overview.aspx). The major difference in approach is that because Unicorn forces all of the merging to be done on the disk, you never have to manually select what to update when you're running a sync operation or remember to write changed items to disk. Unless you have actual collisions, this saves a lot of time because you can take advantage of Git, SVN, TFS, etc to do automerges for you. That said, TDS and Unicorn have different feature sets and goals. TDS is a monolithic product with commercial support and marketing that does a lot more than just serialization. Unicorn is relatively simple, free and open source, and does one thing well. Use whatever makes you happy :)
 
 ## Initial Setup
-* Upgrading from Unicorn 3? Great: it's just a NuGet upgrade away. From [Unicorn 2.x](https://github.com/kamsar/Unicorn/wiki/Upgrading-to-Unicorn-3), you can follow the same directions for 2.x->3.x to go from 2 to 4.
+* Upgrading from Unicorn 3? Great: it's just a NuGet upgrade away. From [Unicorn 2.x](https://github.com/SitecoreUnicorn/Unicorn/wiki/Upgrading-to-Unicorn-3), you can follow the same directions for 2.x->3.x to go from 2 to 4.
 * You'll need Sitecore 7 or later (including 8.x).
 * Install Unicorn. This is as simple as adding the Unicorn NuGet package to your project.
-* When you install the NuGet package, a [README file](https://github.com/kamsar/Unicorn/blob/master/Build/Unicorn.nuget/readme.txt) will come up in Visual Studio with help to get you started.
+* When you install the NuGet package, a [README file](https://github.com/SitecoreUnicorn/Unicorn/blob/master/Build/Unicorn.nuget/readme.txt) will come up in Visual Studio with help to get you started.
 
 ## Using Unicorn
 When using Unicorn it's important to follow the expected workflow.
@@ -30,7 +30,7 @@ When using Unicorn it's important to follow the expected workflow.
 There are a few special features that Unicorn has that are worth mentioning.
 
 * You can define multiple _configurations_, which allow you a lot of flexibility: you can serialize items to different places on disk, set up groups that can be synced separately, and override any aspect of Unicorn in each configuration. Configurations may also define dependencies between each other to enforce a hierarchy.
-* Using Rainbow gives Unicorn a unique, easy to manage [serialization format](http://kamsar.net/index.php/2015/07/Rethinking-the-Sitecore-Serialization-Format-Unicorn-3-Preview-part-1/) and hierarchy.
+* Using Rainbow gives Unicorn a unique, easy to manage [serialization format](https://kamsar.net/index.php/2015/07/Rethinking-the-Sitecore-Serialization-Format-Unicorn-3-Preview-part-1/) and hierarchy.
 * Unicorn rejects "inconsequential" changes to items. The Sitecore Template Editor likes to make a lot of item saves that change nothing but the last modified date and revision. These are ignored to reduce churn in your source control.
 * During a sync operation, Unicorn can detect improperly merged renamed items (e.g. two serialized items with the same ID in different files) and will report that fact as an error.
 * Automatic retries are performed in the event of a load failure during a sync, which means that syncing items with a missing template along with the template itself in the same sync session will work correctly.
@@ -52,14 +52,14 @@ You can find further details about Unicorn 4 at Kam's blog:
 * [Configuration Inheritance and Convention Support](https://kamsar.net/index.php/2017/02/Unicorn-4-Part-III-Configuration-Enhancements/)
 
 There is also a series of blog posts detailing Unicorn 3 (and why the Rainbow serialization format exists) at Kam's blog, which are still relevant:
-* [Unicorn 3: What's New?](http://kamsar.net/index.php/2015/09/Unicorn-3-What-s-new/)
-* [What is Rainbow?](http://kamsar.net/index.php/2015/09/Rainbow-Part-3-What-is-Rainbow/)
-* [Rethinking the Sitecore Serialization Format with Rainbow](http://kamsar.net/index.php/2015/07/Rethinking-the-Sitecore-Serialization-Format-Unicorn-3-Preview-part-1/)
-* [Reinventing the Serialization File System with Rainbow](http://kamsar.net/index.php/2015/08/Reinventing-the-Serialization-File-System-Rainbow-Preview-Part-2/)
+* [Unicorn 3: What's New?](https://kamsar.net/index.php/2015/09/Unicorn-3-What-s-new/)
+* [What is Rainbow?](https://kamsar.net/index.php/2015/09/Rainbow-Part-3-What-is-Rainbow/)
+* [Rethinking the Sitecore Serialization Format with Rainbow](https://kamsar.net/index.php/2015/07/Rethinking-the-Sitecore-Serialization-Format-Unicorn-3-Preview-part-1/)
+* [Reinventing the Serialization File System with Rainbow](https://kamsar.net/index.php/2015/08/Reinventing-the-Serialization-File-System-Rainbow-Preview-Part-2/)
 
 ## Best Practices
 
-* If using [Helix architecture](http://helix.sitecore.net/) plan to use one Unicorn configuration per module. You can use [Unicorn 4's configuration conventions](https://kamsar.net/index.php/2017/02/Unicorn-4-Part-III-Configuration-Enhancements/) to avoid repetition and promote a consistent item architecture across modules.
+* If using [Helix architecture](https://helix.sitecore.net/) plan to use one Unicorn configuration per module. You can use [Unicorn 4's configuration conventions](https://kamsar.net/index.php/2017/02/Unicorn-4-Part-III-Configuration-Enhancements/) to avoid repetition and promote a consistent item architecture across modules.
 * If using Sitecore 9 or the [Sitecore Configuration Roles module](https://github.com/Sitecore/Sitecore-Configuration-Roles), the Unicorn configuration files are automatically enabled or disabled based on the server role that they are deployed to. If not, make sure to enable and disable configuration files appropriately when developing, and deploying to CE/CM and CD environments. Each config file has a comment header that details when it should be enabled and disabled. Most important is to disable the data provider config when deployed.
 * Always automate your deployments of Unicorn items (see _Automated Deployment_ below). This ensures a consistent item state during deployments.
 * Consider automating _local development_ Unicorn syncing using scripts (e.g. PowerShell or Gulp), which can enable you to have a one-click "post-pull" experience that both builds your projects and syncs any item changes in. [Sitecore Habitat](https://github.com/sitecore/habitat) does this using a combination of Gulp and the Unicorn PowerShell API.
@@ -69,7 +69,7 @@ There is also a series of blog posts detailing Unicorn 3 (and why the Rainbow se
 With Unicorn you've got two options for automated deployment of item changes, for example from a Continuous Integration server or production deploy scripts.
 
 ### Use Transparent Sync
-When using [Transparent Sync](http://kamsar.net/index.php/2015/10/Unicorn-Introducing-Transparent-Sync/), the items on disk magically appear in Sitecore without syncing. So one automated deployment option is to simply use Transparent Sync and copy your updated serialized items to the deployment target alongside your code. This is advantageous because it's simple to set up and requires no direct intervention with the deployed server after deployment (e.g. a HTTP call).
+When using [Transparent Sync](https://kamsar.net/index.php/2015/10/Unicorn-Introducing-Transparent-Sync/), the items on disk magically appear in Sitecore without syncing. So one automated deployment option is to simply use Transparent Sync and copy your updated serialized items to the deployment target alongside your code. This is advantageous because it's simple to set up and requires no direct intervention with the deployed server after deployment (e.g. a HTTP call).
 
 ### Use the Automated Tool API
 Unicorn has an automated tool API whereby you can invoke actions in the Unicorn control panel from a script, such as invoking a sync after a code deployment.
@@ -95,7 +95,7 @@ NOTE: When deploying to a Content Editing or Content Delivery server, the Unicor
 
 [Darren Guy](https://twitter.com/DarrenGuy) has written a practical dissertation on his experiences setting up [Unicorn 3 with TeamCity and Octopus Deploy](https://thesoftwaredudeblog.wordpress.com/2016/05/24/building-a-continuous-integration-environment-for-sitecore-part-8-using-unicorn-for-sitecore-item-syncronization/) that goes all the way from install to automated deployment. A recommended read if you're wanting to use a similar setup.
 
-[Andrew Lansdowne](https://twitter.com/Rangler2) has also written a post _(for version 1, so some of it is outdated but the concepts still apply)_ about [setting up Unicorn with TeamCity and WebDeploy](http://andrew.lansdowne.me/2013/06/07/auto-deploy-sitecore-items-using-unicorn-and-teamcity/) that may be useful when setting up automated deployments.
+[Andrew Lansdowne](https://twitter.com/Rangler2) has also written a post _(for version 1, so some of it is outdated but the concepts still apply)_ about [setting up Unicorn with TeamCity and WebDeploy](https://andrew.lansdowne.me/2013/06/07/auto-deploy-sitecore-items-using-unicorn-and-teamcity/) that may be useful when setting up automated deployments.
 
 ## Unicorn's Sync Rules
 

--- a/src/Unicorn.Roles/Data/FilesystemRoleDataStore.cs
+++ b/src/Unicorn.Roles/Data/FilesystemRoleDataStore.cs
@@ -96,7 +96,7 @@ namespace Unicorn.Roles.Data
 			}
 
 			// convert root path to canonical form, so subsequent transformations can do string comparison
-			// http://stackoverflow.com/questions/970911/net-remove-dots-from-the-path
+			// https://stackoverflow.com/questions/970911/net-remove-dots-from-the-path
 			if (rootPath.Contains(".."))
 				rootPath = Path.GetFullPath(rootPath);
 

--- a/src/Unicorn.Roles/Standard Config Files/Unicorn.Configs.Default.Roles.config.example
+++ b/src/Unicorn.Roles/Standard Config Files/Unicorn.Configs.Default.Roles.config.example
@@ -3,7 +3,7 @@
 
 	This is an example of how to configure a basic Unicorn configuration to include a set of security roles to sync.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>

--- a/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.DataProvider.config
+++ b/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.DataProvider.config
@@ -6,7 +6,7 @@
 	This file should be removed in ANY deployed instance (CE or CD) that does not act as a source for serialized role updates.
 	Generally speaking that's anywhere other than a developer workstation, so your CI process (you have one, right?) should remove this file during the build.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone">

--- a/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.config
+++ b/src/Unicorn.Roles/Standard Config Files/Unicorn.Roles.config
@@ -8,7 +8,7 @@
 	Normally this would be development and Content Editing (CE) environments.
 	It should not hurt anything if left in a CD environment, but it may be removed.
 	
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">

--- a/src/Unicorn.Roles/Unicorn.Roles.nuspec
+++ b/src/Unicorn.Roles/Unicorn.Roles.nuspec
@@ -6,12 +6,12 @@
     <title>Unicorn.Roles.Core</title>
     <authors>Kam Figy, Mark Cassidy</authors>
     <owners>Kam Figy</owners>
-    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-    <iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+    <iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds security role syncing to Unicorn. Install the non-core package to get config files.</description>
-    <copyright>Copyright 2018</copyright>
+    <copyright>Copyright 2020</copyright>
     <tags>sitecore serialization</tags>
     <dependencies>
 		<dependency id="Rainbow.Core" version="$rainbowversion$" />

--- a/src/Unicorn.Users/Data/FilesystemUserDataStore.cs
+++ b/src/Unicorn.Users/Data/FilesystemUserDataStore.cs
@@ -94,7 +94,7 @@ namespace Unicorn.Users.Data
 			}
 
 			// convert root path to canonical form, so subsequent transformations can do string comparison
-			// http://stackoverflow.com/questions/970911/net-remove-dots-from-the-path
+			// https://stackoverflow.com/questions/970911/net-remove-dots-from-the-path
 			if (rootPath.Contains(".."))
 				rootPath = Path.GetFullPath(rootPath);
 

--- a/src/Unicorn.Users/Standard Config Files/Unicorn.Configs.Default.Users.config.example
+++ b/src/Unicorn.Users/Standard Config Files/Unicorn.Configs.Default.Users.config.example
@@ -3,7 +3,7 @@
 
 	This is an example of how to configure a basic Unicorn configuration to include a set of users to sync.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>

--- a/src/Unicorn.Users/Standard Config Files/Unicorn.Users.DataProvider.config
+++ b/src/Unicorn.Users/Standard Config Files/Unicorn.Users.DataProvider.config
@@ -6,7 +6,7 @@
 	This file should be removed in ANY deployed instance (CE or CD) that does not act as a source for serialized user updates.
 	Generally speaking that's anywhere other than a developer workstation, so your CI process (you have one, right?) should remove this file during the build.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone">

--- a/src/Unicorn.Users/Standard Config Files/Unicorn.Users.config
+++ b/src/Unicorn.Users/Standard Config Files/Unicorn.Users.config
@@ -8,7 +8,7 @@
 	Normally this would be development and Content Editing (CE) environments.
 	It should not hurt anything if left in a CD environment, but it may be removed.
 	
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">

--- a/src/Unicorn.Users/Unicorn.Users.nuspec
+++ b/src/Unicorn.Users/Unicorn.Users.nuspec
@@ -6,12 +6,12 @@
     <title>Unicorn.Users.Core</title>
     <authors>Kam Figy, Mark Cassidy</authors>
     <owners>Kam Figy</owners>
-    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-    <iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+    <iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds user syncing to Unicorn. Install the non-core package to get config files.</description>
-    <copyright>Copyright 2018</copyright>
+    <copyright>Copyright 2020</copyright>
     <tags>sitecore serialization</tags>
     <dependencies>
 		<dependency id="Rainbow.Storage.Yaml" version="$rainbowversion$" />

--- a/src/Unicorn/Configuration/ConfigurationUtility.cs
+++ b/src/Unicorn/Configuration/ConfigurationUtility.cs
@@ -14,7 +14,7 @@ namespace Unicorn.Configuration
 			if (configPath.StartsWith("~/"))
 			{
 				// +1 to Stack Overflow:
-				// http://stackoverflow.com/questions/4742257/how-to-use-server-mappath-when-httpcontext-current-is-nothing
+				// https://stackoverflow.com/questions/4742257/how-to-use-server-mappath-when-httpcontext-current-is-nothing
 
 				// Support unit testing scenario where hosting environment is not initialized.
 				var hostingRoot = HostingEnvironment.IsHosted

--- a/src/Unicorn/ControlPanel/CheckIfFilterDisablerIsActive.cs
+++ b/src/Unicorn/ControlPanel/CheckIfFilterDisablerIsActive.cs
@@ -4,7 +4,7 @@ namespace Unicorn.ControlPanel
 {
 	/// <summary>
 	/// This is a filterItem pipeline processor that enables arbitrary disabling of item filtering temporarily
-	/// This enables a fix to #26 (https://github.com/kamsar/Unicorn/issues/26) when running in live mode
+	/// This enables a fix to #26 (https://github.com/SitecoreUnicorn/Unicorn/issues/26) when running in live mode
 	/// </summary>
 	public class CheckIfFilterDisablerIsActive
 	{

--- a/src/Unicorn/ControlPanel/Controls/QuickReference.cs
+++ b/src/Unicorn/ControlPanel/Controls/QuickReference.cs
@@ -37,10 +37,10 @@ namespace Unicorn.ControlPanel.Controls
 	<!-- <li><a href=""https://unicorn.kamsar.net/"">Unicorn Book</a></li> -->
 	<li><a href=""#"">Unicorn Book temporarily out of stock. Awaiting reprint.</a></li>
 	<li><a href=""https://github.com/SitecoreUnicorn/Unicorn/tree/master/src/Unicorn/Standard%20Config%20Files"">Default Configuration Files</a></li>
-	<li><a href=""http://kamsar.net/index.php/category/Unicorn/"">Kam Figy's Unicorn Blog Posts</a></li>
+	<li><a href=""https://kamsar.net/index.php/category/Unicorn/"">Kam Figy's Unicorn Blog Posts</a></li>
 	<li><a href=""https://intothecloud.blog/tags/unicorn/"">Mark Cassidy's Unicorn Blog Posts</a></li>
 	<li><a href=""https://intothecloud.blog/tags/rainbow/"">Mark Cassidy's Rainbow Blog Posts</a></li>
-	<li><a href=""https://visualstudiogallery.msdn.microsoft.com/64439022-f470-422a-b663-fbb89aaf6e86"">Unicorn Control Panel for Visual Studio</a></li>
+	<li><a href=""https://marketplace.visualstudio.com/items?itemName=BerserkerDotNet.UnicornControlPanel"">Unicorn Control Panel for Visual Studio</a></li>
 	<li><a href=""https://github.com/SitecoreUnicorn/Unicorn/issues/new"">Found a problem? Report an issue on GitHub.</a></li>
 </ul>
 ");

--- a/src/Unicorn/ControlPanel/ItemFilterDisabler.cs
+++ b/src/Unicorn/ControlPanel/ItemFilterDisabler.cs
@@ -4,7 +4,7 @@ namespace Unicorn.ControlPanel
 {
 	/// <summary>
 	/// Creates a disabler (IDisposable) for disabling item filtering as needed
-	/// This is related to #26 (https://github.com/kamsar/Unicorn/issues/26) when running in live mode and syncing core db items.
+	/// This is related to #26 (https://github.com/SitecoreUnicorn/Unicorn/issues/26) when running in live mode and syncing core db items.
 	/// </summary>
 	public class ItemFilterDisabler : Switcher<ItemFilterDisabler.FilterState>
 	{

--- a/src/Unicorn/Publishing/ManualPublishQueueHandler.cs
+++ b/src/Unicorn/Publishing/ManualPublishQueueHandler.cs
@@ -12,7 +12,7 @@ namespace Unicorn.Publishing
 {
 	/// <summary>
 	/// Maintains a manual publish queue that arbitrary items can be added to
-	/// See http://www.velir.com/blog/index.php/2013/11/22/how-to-create-a-custom-publish-queue-in-sitecore/ among other sources
+	/// See https://www.velir.com/blog/2013/11/22/how-create-custom-publish-queue-sitecore among other sources
 	/// </summary>
 	public class ManualPublishQueueHandler : PublishProcessor
 	{

--- a/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
@@ -5,7 +5,7 @@
 
 	This file should be removed on content delivery environments.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">
@@ -29,7 +29,7 @@
 			<publish>
 				<!--
 					This handler manually injects arbitrary items into the publish queue so that the next publish to occur will cause the injected items to get published. 
-					See http://www.velir.com/blog/index.php/2013/11/22/how-to-create-a-custom-publish-queue-in-sitecore/ et. al.
+					See https://www.velir.com/blog/2013/11/22/how-create-custom-publish-queue-sitecore et. al.
 				-->
 				<processor patch:after="*[@type='Sitecore.Publishing.Pipelines.Publish.AddItemsToQueue, Sitecore.Kernel']" type="Unicorn.Publishing.ManualPublishQueueHandler, Unicorn"/>
 			</publish>

--- a/src/Unicorn/Standard Config Files/Unicorn.Configs.Default.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Configs.Default.example
@@ -6,7 +6,7 @@
 
 	Enabled configuration definition patches should be present on all environments Unicorn is present on.
 
-	See Unicorn.config for commentary on how configurations operate, or https://github.com/kamsar/Unicorn/blob/master/README.md
+	See Unicorn.config for commentary on how configurations operate, or https://github.com/SitecoreUnicorn/Unicorn/blob/master/README.md
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore>
@@ -102,7 +102,7 @@
 						
 						Traditional Sync (the default) updates the state of the database only when a sync operation is run. It supports additional operations but can be more of a chore to remember to sync.
 						Transparent Sync (preferred) updates the state of Sitecore instantly as soon as changes to files occur. It is optimal for development purposes, but has a few limitations.
-						See the guide to help decide: https://github.com/kamsar/Unicorn/wiki/The-Transparent-Sync-Guide
+						See the guide to help decide: https://github.com/SitecoreUnicorn/Unicorn/wiki/The-Transparent-Sync-Guide
 					-->
 					<dataProviderConfiguration enableTransparentSync="false" />
 

--- a/src/Unicorn/Standard Config Files/Unicorn.Configs.Dependency.config.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Configs.Dependency.config.example
@@ -3,7 +3,7 @@
 
 	Enabled configuration definition patches should be present on all environments Unicorn is present on.
 
-	See Unicorn.config for commentary on how configurations operate, or https://github.com/kamsar/Unicorn/blob/master/README.md
+	See Unicorn.config for commentary on how configurations operate, or https://github.com/SitecoreUnicorn/Unicorn/blob/master/README.md
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>

--- a/src/Unicorn/Standard Config Files/Unicorn.Configs.NewItemsOnly.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Configs.NewItemsOnly.example
@@ -7,7 +7,7 @@
 
 	Enabled configuration definition patches should be present on all environments Unicorn is present on.
 
-	See Unicorn.config for commentary on how configurations operate, or https://github.com/kamsar/Unicorn/blob/master/README.md
+	See Unicorn.config for commentary on how configurations operate, or https://github.com/SitecoreUnicorn/Unicorn/blob/master/README.md
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
@@ -27,7 +27,7 @@
 						Note: when using custom evaluators keep Transparent Sync OFF for those configurations (the line below).
 						Transparent Sync operates by reading from the serialization store directly.
 						In other words transparent sync always acts like SerializedAsMasterEvaluator because disk is LITERALLY the master.
-						See https://github.com/kamsar/Unicorn/wiki/The-Transparent-Sync-Guide
+						See https://github.com/SitecoreUnicorn/Unicorn/wiki/The-Transparent-Sync-Guide
 					-->
 					<dataProviderConfiguration enableTransparentSync="false" />
 

--- a/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
@@ -7,7 +7,7 @@
 	Generally speaking that's anywhere other than a developer workstation, so your CI process (you have one, right?) should remove this file during the build.
 	IMPORTANT EXCEPTION: If you are using Transparent Sync as a deployment mechanism, this file must remain on your CE environment.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone">

--- a/src/Unicorn/Standard Config Files/Unicorn.Dilithium.config.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Dilithium.config.example
@@ -23,7 +23,7 @@
 			
 	* If you see uneven timings when running several synchronizations in succession, that's probably the time taken to reload the template field cache, as opposed to spiky SQL times :)
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">

--- a/src/Unicorn/Standard Config Files/Unicorn.PowerShell.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.PowerShell.config
@@ -20,7 +20,7 @@
 	This file should be active on any environment where you wish to execute Unicorn SPE commands. Usually, that'd be dev and CE only. 
 	If you're not using SPE you can disable or remove this file, but it won't hurt anything to leave it either.
 	
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">

--- a/src/Unicorn/Standard Config Files/Unicorn.Remote.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.Remote.config.disabled
@@ -2,13 +2,13 @@
 	Unicorn.Remote.config.disabled
 
 	This file enables the Unicorn control panel remote API. This is used by the Unicorn Control Panel extension for Visual Studio by Andrii Snigyr (@BerserkerDotNet):
-	https://visualstudiogallery.msdn.microsoft.com/64439022-f470-422a-b663-fbb89aaf6e86
+	https://marketplace.visualstudio.com/items?itemName=BerserkerDotNet.UnicornControlPanel
 
 	If you are not using the VS integration, you can safely remove or disable this patch file. To enable this patch file simply remove the .disabled.
 
 	This file should be present only on development environments that are using the VS plugin.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 	https://github.com/BerserkerDotNet/Unicorn.VisualStudio
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.DeployedContentEditorWarnings.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.DeployedContentEditorWarnings.config.disabled
@@ -9,7 +9,7 @@
 	IMPORTANT: THIS CONFIG PATCH *MUST* RUN AFTER Unicorn.UI.config, or you may receive errors in the content editor:
 	"Multiple controls with the same ID 'FContentSOMEGUIDHERESOMEGUIDHERESOMEGUID' were found. FindControl requires that controls have unique IDs."
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="ContentManagement">

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.IdentityServer.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.IdentityServer.config.disabled
@@ -5,7 +5,7 @@
 
 	This file should not be enabled on versions of Sitecore prior to 9.1.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/" xmlns:security="http://www.sitecore.net/xmlconfig/security/">
 	<sitecore role:require="Standalone or ContentManagement" security:require="Sitecore">

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.config
@@ -5,7 +5,7 @@
 	
 	This file should be removed when deploying to Content Delivery environments to remove all Unicorn UI elements, which are not needed in CD.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore role:require="Standalone or ContentManagement">

--- a/src/Unicorn/Standard Config Files/Unicorn.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.config
@@ -8,7 +8,7 @@
 	safe to leave on Content Delivery servers, as it changes no stock Sitecore
 	configuration.
 
-	http://github.com/kamsar/Unicorn
+	https://github.com/SitecoreUnicorn/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
@@ -21,7 +21,7 @@
 				that critical ones can run separately from non-essential ones to save time.
 
 				See the README here for more information:
-				https://github.com/kamsar/Unicorn/blob/master/README.md
+				https://github.com/SitecoreUnicorn/Unicorn/blob/master/README.md
 
 				If you're familiar with DI and IoC containers, each configuration is effectively
 				a dependency container which inherits from the global container defined in

--- a/src/Unicorn/Standard Config Files/Unicorn.zSharedSecret.config.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.zSharedSecret.config.example
@@ -7,7 +7,7 @@ invoking Unicorn with the PowerShell API, e.g. for CI.
 IMPORTANT: THIS CONFIG PATCH *MUST* RUN AFTER Unicorn.UI.config, or you will receive an error:
 "Unable to cast object of type 'System.String' to type 'Unicorn.ControlPanel.Security.IUnicornAuthenticationProvider'."
 
-See the README here for more on setting up remote API: https://github.com/kamsar/Unicorn
+See the README here for more on setting up remote API: https://github.com/SitecoreUnicorn/Unicorn
 
 Need some randomness? Try here: https://www.random.org/passwords/?num=5&len=24&format=html&rnd=new
 -->

--- a/src/Unicorn/Unicorn.nuspec
+++ b/src/Unicorn/Unicorn.nuspec
@@ -6,12 +6,12 @@
     <title>Unicorn.Core</title>
     <authors>Kam Figy, Mark Cassidy</authors>
     <owners>Kam Figy</owners>
-    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/SitecoreUnicorn/Unicorn</projectUrl>
-    <iconUrl>http://kamsar.net/nuget/unicorn/logo.png</iconUrl>
+    <iconUrl>https://kamsar.net/nuget/unicorn/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Unicorn is a utility for Sitecore that solves the issue of moving templates, renderings, and other database items between Sitecore instances.</description>
-    <copyright>Copyright 2018</copyright>
+    <copyright>Copyright 2020</copyright>
     <tags>sitecore serialization</tags>
     <dependencies>
 		<dependency id="Rainbow.Core" version="$rainbowversion$" />


### PR DESCRIPTION
- adjust links (from http to https; or new urls as some have a redirect in place)
- in nuspec chang copyright to 2020
- change from https://github.com/kamsar/Unicorn to https://github.com/SitecoreUnicorn/Unicorn