### PR TITLE
Add Publish Verb to Control Panel

### DIFF
--- a/doc/PowerShell Remote Scripting/sample.ps1
+++ b/doc/PowerShell Remote Scripting/sample.ps1
@@ -18,6 +18,15 @@ Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'yo
 # SYNC ALL CONFIGURATIONS WITHOUT KEEPING CONNECTION OPEN ALL THE TIME (specify configurations if you need only some of them). This is introduced to fix edge case, described https://github.com/SitecoreUnicorn/Unicorn/issues/387 
 Sync-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -Verb 'SyncSilent'
 
+# PUBLISH UNICORN MANUAL QUEUE
+Publish-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here'
+
+# PUBLISH UNICORN MANUAL QUEUE, CUSTOM TARGETS
+Publish-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -Targets @('web','preview')
+
+# PUBLISH UNICORN MANUAL QUEUE, SPECIFIC TRIGGER ITEM
+Publish-Unicorn -ControlPanelUrl 'https://localhost/unicorn.aspx' -SharedSecret 'your-sharedsecret-here' -TriggerItem 'item-path-or-id'
+
 # Note: you may pass -Verb 'Reserialize' for remote reserialize. Usually not needed though.
 
 # Note: If you are having authorization issues, add -DebugSecurity to your cmdlet invocation; this will display the raw signatures being used to compare to the server.

--- a/src/Unicorn/ControlPanel/Pipelines/UnicornControlPanelRequest/PublishVerb.cs
+++ b/src/Unicorn/ControlPanel/Pipelines/UnicornControlPanelRequest/PublishVerb.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Web;
+
+using Kamsar.WebConsole;
+
+using Sitecore.Configuration;
+using Sitecore.Data;
+using Sitecore.Data.Items;
+using Sitecore.Diagnostics;
+
+using Unicorn.ControlPanel.Headings;
+using Unicorn.ControlPanel.Responses;
+using Unicorn.Logging;
+using Unicorn.Publishing;
+
+namespace Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest
+{
+	public class PublishVerb : UnicornControlPanelRequestPipelineProcessor
+	{
+		public PublishVerb() : base("Publish")
+		{
+		}
+
+		protected override IResponse CreateResponse(UnicornControlPanelRequestPipelineArgs args)
+		{
+			return new WebConsoleResponse("Publish Unicorn Queue", args.SecurityState.IsAutomatedTool, new HeadingService(), progress => Process(progress, new WebConsoleLogger(progress, args.Context.Request.QueryString["log"])));
+		}
+
+		protected virtual void Process(IProgressStatus progress, ILogger logger)
+		{
+			try
+			{
+				if (ManualPublishQueueHandler.HasItemsToPublish)
+				{
+					Item trigger = GetTriggerItem();
+					Database[] targets = GetTargets();
+
+					Log.Info("Unicorn: initiated synchronous publishing of synced items.", this);
+					if (ManualPublishQueueHandler.PublishQueuedItems(trigger, targets, logger))
+					{
+						Log.Info("Unicorn: publishing of synced items is complete.", this);
+					}
+				}
+				else
+				{
+					logger.Warn("[Unicorn Publish] There were no items to publish.");
+				}
+			}
+			catch (Exception ex)
+			{
+				logger.Error(ex);
+			}
+		}
+
+		protected virtual Item GetTriggerItem()
+		{
+			Item result;
+			string triggerIdOrPath = HttpContext.Current.Request.QueryString["trigger"];
+			if (!string.IsNullOrWhiteSpace(triggerIdOrPath))
+			{
+				result = Factory.GetDatabase("master").GetItem(triggerIdOrPath);
+				if (result == null || result.Empty)
+				{
+					throw new ArgumentException($"No item found for '{triggerIdOrPath}'.", "trigger");
+				}
+			}
+			else
+			{
+				throw new ArgumentNullException("trigger");
+			}
+
+			return result;
+		}
+
+		protected virtual Database[] GetTargets()
+		{
+			Database[] result;
+			string targets = HttpContext.Current.Request.QueryString["targets"];
+			if (!string.IsNullOrWhiteSpace(targets))
+			{
+				string[] targetNames = targets.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				result = targetNames.Select(Factory.GetDatabase).ToArray();
+				if (result.Length <= 0)
+				{
+					throw new ArgumentException("At least 1 valid target should be specified.", "targets");
+				}
+			}
+			else
+			{
+				throw new ArgumentNullException("targets");
+			}
+
+			return result;
+		}
+	}
+}

--- a/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
@@ -16,7 +16,10 @@
 			</unicornSyncComplete>
 
 			<unicornSyncEnd>
-				<!-- when all configurations have synced, fire off a publish that processes the queue we've accumulated -->
+				<!-- 
+					When all configurations have synced, fire off a publish that processes the queue we've accumulated.
+					Alternatively you can disable this processor and call the Unicorn Control Panel with the "Publish" verb for control over the timing of this publish.
+				-->
 				<processor type="Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems, Unicorn">
 					<PublishTriggerItemId>/sitecore/templates/Common/Folder</PublishTriggerItemId>
 					<!-- the trigger item can be any leaf node Sitecore item - just has to have a 'starting point' for the publish -->

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.config
@@ -75,6 +75,7 @@
 				<processor type="Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest.ReserializeVerb, Unicorn" />
 				<processor type="Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest.HandleAccessDenied, Unicorn" />
 				<processor type="Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest.RenderControlPanel, Unicorn" />
+				<processor type="Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest.PublishVerb, Unicorn" />
 			</unicornControlPanelRequest>
 		</pipelines>
 

--- a/src/Unicorn/Unicorn.csproj
+++ b/src/Unicorn/Unicorn.csproj
@@ -91,6 +91,7 @@
     <Compile Include="ControlPanel\Controls\GlobalWarnings.cs" />
     <Compile Include="ControlPanel\Controls\QuickReference.cs" />
     <Compile Include="ControlPanel\Controls\NoConfigurations.cs" />
+    <Compile Include="ControlPanel\Pipelines\UnicornControlPanelRequest\PublishVerb.cs" />
     <Compile Include="ControlPanel\Pipelines\UnicornControlPanelRequest\SyncSilentVerb.cs" />
     <Compile Include="ControlPanel\Security\ChallengeStoreSitecoreLogger.cs" />
     <Compile Include="ControlPanel\Security\ChapServerSitecoreLogger.cs" />


### PR DESCRIPTION
The Publish verb takes a "trigger" and "targets" parameter just as the ootb TriggerAutoPublishSyncedItems processor.
- trigger can be an ID or path
- targets is a comma seperated list of publish target names (ea "web" or "web,preview")

This verb can be used to trigger the Unicorn Publish Manual Queue incase you desire to delay its execution for DevOps reasons. Make sure to disable the TriggerAutoPublishSyncedItems processor if this is desired.