### PR TITLE
Add support for exclude exception by template ID

### DIFF
--- a/src/Unicorn.Roles.Tests/Unicorn.Roles.Tests.csproj
+++ b/src/Unicorn.Roles.Tests/Unicorn.Roles.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -92,6 +95,12 @@
     <EmbeddedResource Include="RolePredicates\TestConfiguration.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Unicorn.Roles.Tests/packages.config
+++ b/src/Unicorn.Roles.Tests/packages.config
@@ -8,4 +8,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/Unicorn.Tests/Configuration/ConfigurationUtilityTests.cs
+++ b/src/Unicorn.Tests/Configuration/ConfigurationUtilityTests.cs
@@ -23,8 +23,15 @@ namespace Unicorn.Tests.Configuration
 		[Fact]
 		public void ResolveConfigurationPath_ResolvesExpectedPath_WhenPathIsRelative()
 		{
+			// some test runners (e.g. Resharper) already have the trailing '\\' on BaseDirectory
+			var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			if (!baseDirectory.EndsWith("\\"))
+			{
+				baseDirectory += "\\";
+			}
+
 			// HostingEnvironment returns null out of web context so root = empty string
-			ConfigurationUtility.ResolveConfigurationPath("~/../hello").Should().Be($"{AppDomain.CurrentDomain.BaseDirectory}\\..\\hello");
+			ConfigurationUtility.ResolveConfigurationPath("~/../hello").Should().Be($"{baseDirectory}..\\hello"); 
 		}
 	}
 }

--- a/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
+++ b/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
@@ -129,6 +129,32 @@ namespace Unicorn.Tests.Predicates
 			predicate.Includes(mismatchedCasePathItem).IsIncluded.Should().Be(expectedResult);
 		}
 
+
+		//
+		// TEMPLATE ID INCLUSION/EXCLUSION
+		//
+
+		[Theory]
+		// TEMPLATE ID
+		[InlineData("/sitecore/allowed/excludedchild", "{3B4F2B85-778D-44F3-9B2D-BEFF1F3575E6}", false)]
+		[InlineData("/sitecore/allowed/includedchild", "{11111111-1111-1111-1111-111111111111}", true)]
+		// TEMPLATE ID - exclude
+		[InlineData("/sitecore/excluded/includedchild", "{3B4F2B85-778D-44F3-9B2D-BEFF1F3575E6}", true)]
+		[InlineData("/sitecore/excluded/excludedchild", "{11111111-1111-1111-1111-111111111111}", false)]
+		// EXCLUDE EXCEPT TEMPLATE
+		[InlineData("/sitecore/exclude-except-template/excluded", "{11111111-1111-1111-1111-111111111111}", false)]
+		[InlineData("/sitecore/exclude-except-template/included", "{A87A00B1-E6DB-45AB-8B54-636FEC3B5523}", true)]
+		[InlineData("/sitecore/exclude-except-template/another/included", "{FE5DD826-48C6-436D-B87A-7C4210C7413B}", true)]
+		public void Includes_MatchesExpectedTemplateIdResult(string testPath, string templateId, bool expectedResult)
+		{
+			var predicate = CreateTestPredicate(CreateTestConfiguration());
+			var item = CreateTestItem(testPath, "master", templateId);
+
+			var actualResult = predicate.Includes(item);
+
+			actualResult.IsIncluded.Should().Be(expectedResult);
+		}
+
 		//
 		// DATABASE INCLUSION/EXCLUSION
 		//
@@ -156,7 +182,7 @@ namespace Unicorn.Tests.Predicates
 
 			var roots = predicate.GetRootPaths();
 
-			roots.Length.Should().Be(16);
+			roots.Length.Should().Be(17);
 
 			var basicRoot = roots.FirstOrDefault(root => root.Name.Equals("Basic"));
 			basicRoot?.DatabaseName.Should().Be("master");

--- a/src/Unicorn.Tests/Predicates/TestConfiguration.xml
+++ b/src/Unicorn.Tests/Predicates/TestConfiguration.xml
@@ -41,6 +41,17 @@
 		<exclude templateId="{11111111-1111-1111-1111-111111111111}" />
 		<!--all test items are created with the following templateId-->
 	</include>
+
+	<!-- 
+		EXCLUDE EXCEPT TEMPLATE: Include parent, exclude all children EXCEPT for specific ones
+		NOTE: template ID exceptions DO NOT support includeChildren
+	-->
+	<include name="Some children by template" database="master" path="/sitecore/exclude-except-template">
+		<exclude children="true">
+			<except templateId="{A87A00B1-E6DB-45AB-8B54-636FEC3B5523}" />
+			<except templateId="{FE5DD826-48C6-436D-B87A-7C4210C7413B}"  />
+		</exclude>
+	</include>
 	
 	<!-- 
 		NAME PATTERN: Exclude items whose name matches a regex pattern

--- a/src/Unicorn.Tests/Unicorn.Tests.csproj
+++ b/src/Unicorn.Tests/Unicorn.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -211,6 +212,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Unicorn.Tests/packages.config
+++ b/src/Unicorn.Tests/packages.config
@@ -39,4 +39,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/Unicorn/Predicates/ExceptionRule.cs
+++ b/src/Unicorn/Predicates/ExceptionRule.cs
@@ -1,8 +1,11 @@
-﻿namespace Unicorn.Predicates
+﻿using System;
+
+namespace Unicorn.Predicates
 {
 	public class ExceptionRule
 	{
 		public string Name { get; set; }
 		public bool IncludeChildren { get; set; }
+		public string TemplateId { get; set; }
 	}
 }

--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -24,7 +24,7 @@ namespace Unicorn.Predicates
 		{
 			Assert.ArgumentNotNull(configNode, "configNode");
 
-			_predicatePresetHandler = configuration.Resolve<IPredicatePresetHandler>();
+			_predicatePresetHandler = configuration?.Resolve<IPredicatePresetHandler>();
 
 			_includeEntries = ParsePreset(configNode, configuration?.Name);
 


### PR DESCRIPTION
There is was previous support for excluding items with a specific template ID, but not for the inverse, excluding items except those with a specific template ID. This will add support for configuration like the following: 

```
<include name="example" database="master" path="/sitecore/content/example">
    <exclude children="true">
        <except templateId="{A87A00B1-E6DB-45AB-8B54-636FEC3B5523}" />
    </exclude>
</include>
```

Note that `<except>` nodes can use either a `name` or a `templateId` attribute, but not both. If both are present, the `name` attribute will take precedence. Also note that the `includeChildren` attribute is not supported with `templateId`.