### PR TITLE
Bugfix/429 deserialize failure retryer security disabler

### DIFF
--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("Unicorn")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("4.1.6.0")]
-[assembly: AssemblyFileVersion("4.1.6.0")]
-[assembly: AssemblyInformationalVersion("4.1.6")]
+[assembly: AssemblyVersion("4.1.6.1")]
+[assembly: AssemblyFileVersion("4.1.6.1")]
+[assembly: AssemblyInformationalVersion("4.1.6-Issue429")]
 [assembly: CLSCompliant(false)]

--- a/src/Unicorn.Tests/Unicorn.Tests.csproj
+++ b/src/Unicorn.Tests/Unicorn.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -211,6 +212,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Unicorn.Tests/packages.config
+++ b/src/Unicorn.Tests/packages.config
@@ -39,4 +39,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This PR aims to fix [issue #429](https://github.com/SitecoreUnicorn/Unicorn/issues/429)

Unlike the SerializationLoader, if DeserializeFailureRetryer is triggered, it does not wrap the calls to DoLoadItem() and DoLoadTree() in a UnicornOperationContext.

This PR adds a test case to demonstrate the issue and a fix to make it pass.

